### PR TITLE
Refactor and Improve CMED Processing Pipeline Functions

### DIFF
--- a/etl_functions.py
+++ b/etl_functions.py
@@ -450,13 +450,8 @@ def sort_alphabetically(text):
     str
         A string with the same words, reordered alphabetically.
     """
-    tokens = word_tokenize(text)
-
-    if len(tokens) > 1:
-        tokens.sort()
-        text = " ".join(tokens)
     
-    return text
+    return " ".join(sorted(word_tokenize(text)))
 
 def load_notice(path, sep = ';', decimal = ','):
     """

--- a/etl_functions.py
+++ b/etl_functions.py
@@ -47,10 +47,10 @@ def std_cols_names(df_cmed):
     new_df = df_cmed.copy()
 
     # Turn to lowercase + remove accents + change blank spaces for "_"
-    new_df.rename(str.lower, axis = 'columns', inplace = True)
-    new_df.rename(unidecode, axis = 'columns', inplace = True)
-    new_df.rename(lambda x : x.replace(' ', "_"), axis = 'columns',
-                  inplace = True)
+    new_df.columns = [
+        unidecode(col.lower()).replace(' ', '_')
+        for col in new_df.columns
+    ]
     
     return new_df
 

--- a/etl_functions.py
+++ b/etl_functions.py
@@ -25,9 +25,7 @@ def load_cmed(path, sep=';'):
         A DataFrame containing the data from the CMED file.
     """
 
-    df_cmed = pd.read_csv(path, sep = sep)
-
-    return df_cmed
+    return pd.read_csv(path, sep = sep)
 
 def std_cols_names(df_cmed):
     """

--- a/etl_functions.py
+++ b/etl_functions.py
@@ -474,8 +474,5 @@ def load_notice(path, sep = ';', decimal = ','):
     DataFrame
         A DataFrame containing the data from the Public Notice file.
     """
-    
-    # Load the .csv
-    df_le = pd.read_csv(path, sep = sep, decimal = decimal)
 
-    return df_le
+    return pd.read_csv(path, sep = sep, decimal = decimal)

--- a/etl_functions.py
+++ b/etl_functions.py
@@ -111,11 +111,12 @@ def std_preprocessing(text, correct_ai = False, rem_nums = False,
         The preprocessed text.
     """
 
-    text = text.lower()                   # Apply lowercase
-    text = unidecode(text)                # Remove acentuacion
+    # Lowercase and remove accents
+    text = unidecode(text.lower())
+    # Remove URLs
+    text = re.sub(r'http\S+|www\S+', '', text)
+    # Remove special characters (keep only words and numbers)
     text = re.sub('\W',' ', text)         # Removes specials characters and leaves only words
-    text = re.sub(r'http\S+', '', text)   # Removes URLs with http
-    text = re.sub(r'www\S+', '', text)    # Removes URLs with www
 
     tokens = word_tokenize(text)
 
@@ -163,24 +164,20 @@ def std_preprocessing(text, correct_ai = False, rem_nums = False,
                         'tenoxican': 'tenoxicam',
                         'trimetroprima': 'trimetoprima'}
         
-        triggers = CORRECTIONS.keys()
-        tokens = [CORRECTIONS[tok] if tok in triggers else tok for tok in tokens]
+        tokens = [CORRECTIONS.get(tok, tok) for tok in tokens]
 
     # Insert blank space between numbers and words
-    text = ""
+    new_tokens = []
     for tok in tokens:
-        match = re.split(r'(\d+)', tok)
-        if (len(match) > 1):
-            for m in match:
-                text += m + " "
-        else:
-            text += tok + " "
+        # Split tokens into words and numbers
+        split_tok = re.findall(r'[A-Za-z]+|\d+', tok)
+
+        new_tokens.extend(split_tok)
+    tokens = new_tokens
 
     # Remove numbers
     if rem_nums:
-        text = re.sub('\d', ' ', text)
-
-    tokens = word_tokenize(text)
+        tokens = [tok for tok in tokens if not tok.isdigit()]
 
     # Remove words that hinder the identification of pharmaceutical active ingredients
     if rem_stopwords_ai:
@@ -210,6 +207,7 @@ def std_preprocessing(text, correct_ai = False, rem_nums = False,
     # Remove words that hinder the identification of presentations
     if rem_stopwords_pr:
         STOPWORDS_PR = ['embalagem', 'agua', 'de', 'para', 'sodio', 'e']
+        
         tokens = [tok for tok in tokens if tok not in STOPWORDS_PR]
 
     # Abbreviate presentation components based on the ANVISA vocabulary
@@ -350,18 +348,24 @@ def std_preprocessing(text, correct_ai = False, rem_nums = False,
                         'vidro': 'vd',
                         'xampu': 'xamp',
                         'xarope': 'xpe'}
-        forms = ANVISA_ABBREVIATOR.keys()
-
-        tokens = [ANVISA_ABBREVIATOR[tok] if tok in forms else tok for tok in tokens]
+        
+        tokens = [ANVISA_ABBREVIATOR.get(tok, tok) for tok in tokens]
 
     # Removal of repeated words
     if rem_rep_tokens:
-        indexes = np.unique(tokens, return_index=True)[1]
-        tokens = [tokens[index] for index in sorted(indexes)]
+        seen = set()
 
-    text = " ".join(tokens)
+        filtered_tokens = []
+        for x in tokens:
+            if x in seen:
+                continue
 
-    return text
+            seen.add(x)
+            filtered_tokens.append(x)
+
+        tokens = filtered_tokens
+
+    return " ".join(tokens)
 
 def grouped_cmed(df_cmed, ai_column, verbose = False):
     """

--- a/etl_functions.py
+++ b/etl_functions.py
@@ -6,7 +6,7 @@ from nltk.tokenize import word_tokenize
 from tqdm import tqdm
 from unidecode import unidecode
 
-def load_cmed(path, sep=';'):
+def load_cmed(path, sep = ';'):
     """
     Load the CMED dataset from a .csv file
     
@@ -27,7 +27,7 @@ def load_cmed(path, sep=';'):
 
     return pd.read_csv(path, sep = sep)
 
-def std_cols_names(df_cmed):
+def std_cols_names_preprocessing(df_cmed):
     """
     Standardizes column names by converting them to lowercase, removing
     accents, and replacing spaces with underscores.
@@ -367,7 +367,7 @@ def std_preprocessing(text, correct_ai = False, rem_nums = False,
 
     return " ".join(tokens)
 
-def grouped_cmed(df_cmed, ai_column, verbose = False):
+def group_cmed(df_cmed, ai_column, verbose = False):
     """
     Creates a dictionary-like DataFrame where the "keys" are pharmaceutical
     active ingredients and the "values" are the indices of CMED rows that
@@ -393,68 +393,48 @@ def grouped_cmed(df_cmed, ai_column, verbose = False):
         associated row indices from the original CMED data, and the ingredient
         name sorted alphabetically.
     """
-    # Create a list with all the distinct pharmaceutical active ingredients    
-    ais = np.unique(df_cmed[ai_column])
+    # Create a list with all the distinct pharmaceutical active ingredients
+    ais = df_cmed[ai_column].unique()
+
+    if verbose:
+        ais = tqdm(ais, desc = "Grouping active ingredients")
     
-    ### Creation of the DataFrame
+    # Creation of the DataFrame
     keys = []
     keys_sorted = []
     indexes = []
 
-    if verbose:
-        print("Creation of the grouped-cmed DataFrame")
-        ais = tqdm(ais)
-
-
     for key in ais:
-        # Find the rows of CMED that have the pharmaceutical ingredient stored in key
+        # Find the rows of CMED that have the pharmaceutical ingredient of the
+        # current key
         indexes_found = df_cmed.index[df_cmed[ai_column] == key].values
 
         keys.append(key)
         keys_sorted.append(sort_alphabetically(key))
         indexes.append(np.unique(indexes_found))
     
-    data = {'key': keys,
-            'key_sorted': keys_sorted,
-            'indexes': indexes}
+    df_grouped_cmed = pd.DataFrame({
+        'key': keys,
+        'key_sorted': keys_sorted,
+        'indexes': indexes
+    })
 
-    df_grouped_cmed = pd.DataFrame(data)
+    ### Dealing with duplicated key_sorted lines
+    duplicated = df_grouped_cmed[df_grouped_cmed.duplicated(subset = ['key_sorted'],
+                                                            keep = False)]
 
-    ### Dealing with duplicated lines
-
-    duplicated = df_grouped_cmed[df_grouped_cmed.duplicated(subset=['key_sorted'], keep=False)]
-
-    keys = []
-    keys_sorted = []
-    indexes = []
-
-    ais_sorted = np.unique(duplicated['key_sorted'])
-    if verbose:
-        print("Dealing with duplicated pharmaceutical active ingredients")
-        ais_sorted = tqdm(ais_sorted)
-
-    for ksort in ais_sorted:
-        subset = duplicated[duplicated['key_sorted'] == ksort].reset_index(drop = True)
-
-        keys.append(subset['key'][0])
-        keys_sorted.append(ksort)
+    if not duplicated.empty:
+        # Aggregate indexes for each duplicated key_sorted
+        agg = duplicated.groupby('key_sorted').agg({
+            'key': 'first',
+            'indexes': lambda idxs: np.unique(np.concatenate(idxs.tolist()))
+        }).reset_index()
         
-        new_indexes = []
-        for ind in subset['indexes']:
-            new_indexes.extend(ind)
+        # Remove old duplicates and add aggregated ones
+        df_grouped_cmed = df_grouped_cmed.drop(duplicated.index)
+        df_grouped_cmed = pd.concat([df_grouped_cmed, agg], ignore_index =True)
 
-        indexes.append(np.unique(new_indexes))
-
-
-    data = {'key': keys,
-            'key_sorted': keys_sorted,
-            'indexes': indexes}
-
-    new_lines = pd.DataFrame(data).sort_values(by='key_sorted')
-    df_grouped_cmed.drop_duplicates(subset=['key_sorted'], keep = False, inplace = True)
-    df_grouped_cmed = pd.concat([df_grouped_cmed, new_lines], ignore_index = True)
-
-    return df_grouped_cmed.sort_values(by=['key']).reset_index(drop = True)
+    return df_grouped_cmed.sort_values(by = ['key']).reset_index(drop = True)
 
 def sort_alphabetically(text):
     """

--- a/example_notebook.ipynb
+++ b/example_notebook.ipynb
@@ -249,28 +249,16 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 4,
    "metadata": {},
-   "outputs": [
-    {
-     "ename": "AttributeError",
-     "evalue": "module 'etl_functions' has no attribute 'std_cols_names'",
-     "output_type": "error",
-     "traceback": [
-      "\u001b[0;31m---------------------------------------------------------------------------\u001b[0m",
-      "\u001b[0;31mAttributeError\u001b[0m                            Traceback (most recent call last)",
-      "Cell \u001b[0;32mIn[3], line 1\u001b[0m\n\u001b[0;32m----> 1\u001b[0m df_cmed \u001b[38;5;241m=\u001b[39m \u001b[43metl\u001b[49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43mstd_cols_names\u001b[49m(df_cmed)\n",
-      "\u001b[0;31mAttributeError\u001b[0m: module 'etl_functions' has no attribute 'std_cols_names'"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "df_cmed = etl.std_cols_names_preprocessing(df_cmed)"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 5,
    "metadata": {},
    "outputs": [
     {
@@ -474,7 +462,7 @@
        "[29866 rows x 8 columns]"
       ]
      },
-     "execution_count": 4,
+     "execution_count": 5,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -499,14 +487,21 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 6,
    "metadata": {},
    "outputs": [
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "29866it [00:17, 1712.90it/s]\n"
+      "0it [00:00, ?it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "29866it [00:09, 3215.70it/s]\n"
      ]
     }
    ],
@@ -526,7 +521,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 7,
    "metadata": {},
    "outputs": [
     {
@@ -730,7 +725,7 @@
        "[29866 rows x 8 columns]"
       ]
      },
-     "execution_count": 6,
+     "execution_count": 7,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -748,45 +743,24 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 9,
    "metadata": {},
    "outputs": [
     {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Creation of the grouped-cmed DataFrame\n"
-     ]
-    },
-    {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "100%|██████████| 2140/2140 [00:04<00:00, 458.93it/s]\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Dealing with duplicated pharmaceutical active ingredients\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "100%|██████████| 57/57 [00:00<00:00, 2779.17it/s]\n"
+      "Grouping active ingredients: 100%|██████████| 2140/2140 [00:05<00:00, 391.57it/s]\n"
      ]
     }
    ],
    "source": [
-    "grouped_cmed = etl.grouped_cmed(df_cmed, 'substancia', verbose = True)"
+    "grouped_cmed = etl.group_cmed(df_cmed, 'substancia', verbose = True)"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 10,
    "metadata": {},
    "outputs": [
     {
@@ -917,7 +891,7 @@
        "[2072 rows x 3 columns]"
       ]
      },
-     "execution_count": 8,
+     "execution_count": 10,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -935,7 +909,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 11,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -947,7 +921,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 12,
    "metadata": {},
    "outputs": [
     {
@@ -957,7 +931,7 @@
        "       'zuclopentixol'], dtype='<U30')"
       ]
      },
-     "execution_count": 10,
+     "execution_count": 12,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -969,7 +943,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 13,
    "metadata": {},
    "outputs": [
     {
@@ -978,7 +952,7 @@
        "array(['0', '00', '000', ..., 'xamp', 'xpe', 'xpect'], dtype='<U16')"
       ]
      },
-     "execution_count": 11,
+     "execution_count": 13,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -997,7 +971,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 14,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1006,7 +980,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 15,
    "metadata": {},
    "outputs": [
     {
@@ -1173,7 +1147,7 @@
        "[199 rows x 6 columns]"
       ]
      },
-     "execution_count": 13,
+     "execution_count": 15,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1191,7 +1165,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 16,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1200,7 +1174,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 17,
    "metadata": {},
    "outputs": [
     {
@@ -1331,7 +1305,7 @@
        "[199 rows x 3 columns]"
       ]
      },
-     "execution_count": 15,
+     "execution_count": 17,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1356,7 +1330,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 18,
    "metadata": {},
    "outputs": [
     {
@@ -1370,7 +1344,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "199it [00:00, 2044.87it/s]\n"
+      "199it [00:00, 1150.26it/s]\n"
      ]
     }
    ],
@@ -1399,7 +1373,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 19,
    "metadata": {},
    "outputs": [
     {
@@ -1554,7 +1528,7 @@
        "[199 rows x 5 columns]"
       ]
      },
-     "execution_count": 17,
+     "execution_count": 19,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1572,14 +1546,36 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 20,
    "metadata": {},
    "outputs": [
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "199it [00:12, 15.54it/s]\n"
+      "0it [00:00, ?it/s]\n"
+     ]
+    },
+    {
+     "ename": "ValueError",
+     "evalue": "setting an array element with a sequence.",
+     "output_type": "error",
+     "traceback": [
+      "\u001b[0;31m---------------------------------------------------------------------------\u001b[0m",
+      "\u001b[0;31mTypeError\u001b[0m                                 Traceback (most recent call last)",
+      "\u001b[0;31mTypeError\u001b[0m: only size-1 arrays can be converted to Python scalars",
+      "\nThe above exception was the direct cause of the following exception:\n",
+      "\u001b[0;31mValueError\u001b[0m                                Traceback (most recent call last)",
+      "Cell \u001b[0;32mIn[20], line 10\u001b[0m\n\u001b[1;32m      7\u001b[0m desc_ai, desc_pr \u001b[38;5;241m=\u001b[39m ir_med\u001b[38;5;241m.\u001b[39msplit_description(row_X[\u001b[38;5;124m'\u001b[39m\u001b[38;5;124mdesc\u001b[39m\u001b[38;5;124m'\u001b[39m], cmed_ai_words, cmed_pr_words)\n\u001b[1;32m      9\u001b[0m \u001b[38;5;66;03m# Função de classificação\u001b[39;00m\n\u001b[0;32m---> 10\u001b[0m df_notice\u001b[38;5;241m.\u001b[39mat[idx_X, \u001b[38;5;124m'\u001b[39m\u001b[38;5;124mcmed_indexes\u001b[39m\u001b[38;5;124m'\u001b[39m], process_metadata \u001b[38;5;241m=\u001b[39m \u001b[43mir_med\u001b[49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43mpredict\u001b[49m\u001b[43m(\u001b[49m\u001b[43mdf_cmed\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[43mgrouped_cmed\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[43mdesc_ai\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[43mdesc_pr\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[43mrow_X\u001b[49m\u001b[43m[\u001b[49m\u001b[38;5;124;43m'\u001b[39;49m\u001b[38;5;124;43mund\u001b[39;49m\u001b[38;5;124;43m'\u001b[39;49m\u001b[43m]\u001b[49m\u001b[43m)\u001b[49m\n\u001b[1;32m     12\u001b[0m \u001b[38;5;28;01mif\u001b[39;00m SAVE_PROCESS_METADATA:\n\u001b[1;32m     13\u001b[0m     \u001b[38;5;28;01mfor\u001b[39;00m key, value \u001b[38;5;129;01min\u001b[39;00m process_metadata\u001b[38;5;241m.\u001b[39mitems():\n",
+      "File \u001b[0;32m~/Documentos/Code/ir-med/ir_med.py:119\u001b[0m, in \u001b[0;36mpredict\u001b[0;34m(df_cmed, grouped_cmed, desc_ai, desc_pr, und)\u001b[0m\n\u001b[1;32m    117\u001b[0m \u001b[38;5;66;03m# Colect medicines that have the active ingredient\u001b[39;00m\n\u001b[1;32m    118\u001b[0m idxs \u001b[38;5;241m=\u001b[39m grouped_cmed\u001b[38;5;241m.\u001b[39mloc[grouped_cmed[\u001b[38;5;124m'\u001b[39m\u001b[38;5;124mkey\u001b[39m\u001b[38;5;124m'\u001b[39m] \u001b[38;5;241m==\u001b[39m ai_found, \u001b[38;5;124m'\u001b[39m\u001b[38;5;124mindexes\u001b[39m\u001b[38;5;124m'\u001b[39m]\n\u001b[0;32m--> 119\u001b[0m df_cmed_filtered \u001b[38;5;241m=\u001b[39m \u001b[43mdf_cmed\u001b[49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43miloc\u001b[49m\u001b[43m[\u001b[49m\u001b[43midxs\u001b[49m\u001b[43m]\u001b[49m\n\u001b[1;32m    121\u001b[0m \u001b[38;5;66;03m# Filter medicines based on the pharmaceutical presentation\u001b[39;00m\n\u001b[1;32m    122\u001b[0m best_matches, filter_prs_metadata \u001b[38;5;241m=\u001b[39m filter_prs(df_cmed_filtered, desc_ai,\n\u001b[1;32m    123\u001b[0m                                              desc_pr, und, ai_found)\n",
+      "File \u001b[0;32m~/anaconda3/lib/python3.9/site-packages/pandas/core/indexing.py:967\u001b[0m, in \u001b[0;36m_LocationIndexer.__getitem__\u001b[0;34m(self, key)\u001b[0m\n\u001b[1;32m    964\u001b[0m axis \u001b[38;5;241m=\u001b[39m \u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39maxis \u001b[38;5;129;01mor\u001b[39;00m \u001b[38;5;241m0\u001b[39m\n\u001b[1;32m    966\u001b[0m maybe_callable \u001b[38;5;241m=\u001b[39m com\u001b[38;5;241m.\u001b[39mapply_if_callable(key, \u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39mobj)\n\u001b[0;32m--> 967\u001b[0m \u001b[38;5;28;01mreturn\u001b[39;00m \u001b[38;5;28;43mself\u001b[39;49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43m_getitem_axis\u001b[49m\u001b[43m(\u001b[49m\u001b[43mmaybe_callable\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[43maxis\u001b[49m\u001b[38;5;241;43m=\u001b[39;49m\u001b[43maxis\u001b[49m\u001b[43m)\u001b[49m\n",
+      "File \u001b[0;32m~/anaconda3/lib/python3.9/site-packages/pandas/core/indexing.py:1514\u001b[0m, in \u001b[0;36m_iLocIndexer._getitem_axis\u001b[0;34m(self, key, axis)\u001b[0m\n\u001b[1;32m   1512\u001b[0m \u001b[38;5;66;03m# a list of integers\u001b[39;00m\n\u001b[1;32m   1513\u001b[0m \u001b[38;5;28;01melif\u001b[39;00m is_list_like_indexer(key):\n\u001b[0;32m-> 1514\u001b[0m     \u001b[38;5;28;01mreturn\u001b[39;00m \u001b[38;5;28;43mself\u001b[39;49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43m_get_list_axis\u001b[49m\u001b[43m(\u001b[49m\u001b[43mkey\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[43maxis\u001b[49m\u001b[38;5;241;43m=\u001b[39;49m\u001b[43maxis\u001b[49m\u001b[43m)\u001b[49m\n\u001b[1;32m   1516\u001b[0m \u001b[38;5;66;03m# a single integer\u001b[39;00m\n\u001b[1;32m   1517\u001b[0m \u001b[38;5;28;01melse\u001b[39;00m:\n\u001b[1;32m   1518\u001b[0m     key \u001b[38;5;241m=\u001b[39m item_from_zerodim(key)\n",
+      "File \u001b[0;32m~/anaconda3/lib/python3.9/site-packages/pandas/core/indexing.py:1485\u001b[0m, in \u001b[0;36m_iLocIndexer._get_list_axis\u001b[0;34m(self, key, axis)\u001b[0m\n\u001b[1;32m   1468\u001b[0m \u001b[38;5;250m\u001b[39m\u001b[38;5;124;03m\"\"\"\u001b[39;00m\n\u001b[1;32m   1469\u001b[0m \u001b[38;5;124;03mReturn Series values by list or array of integers.\u001b[39;00m\n\u001b[1;32m   1470\u001b[0m \n\u001b[0;32m   (...)\u001b[0m\n\u001b[1;32m   1482\u001b[0m \u001b[38;5;124;03m`axis` can only be zero.\u001b[39;00m\n\u001b[1;32m   1483\u001b[0m \u001b[38;5;124;03m\"\"\"\u001b[39;00m\n\u001b[1;32m   1484\u001b[0m \u001b[38;5;28;01mtry\u001b[39;00m:\n\u001b[0;32m-> 1485\u001b[0m     \u001b[38;5;28;01mreturn\u001b[39;00m \u001b[38;5;28;43mself\u001b[39;49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43mobj\u001b[49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43m_take_with_is_copy\u001b[49m\u001b[43m(\u001b[49m\u001b[43mkey\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[43maxis\u001b[49m\u001b[38;5;241;43m=\u001b[39;49m\u001b[43maxis\u001b[49m\u001b[43m)\u001b[49m\n\u001b[1;32m   1486\u001b[0m \u001b[38;5;28;01mexcept\u001b[39;00m \u001b[38;5;167;01mIndexError\u001b[39;00m \u001b[38;5;28;01mas\u001b[39;00m err:\n\u001b[1;32m   1487\u001b[0m     \u001b[38;5;66;03m# re-raise with different error message\u001b[39;00m\n\u001b[1;32m   1488\u001b[0m     \u001b[38;5;28;01mraise\u001b[39;00m \u001b[38;5;167;01mIndexError\u001b[39;00m(\u001b[38;5;124m\"\u001b[39m\u001b[38;5;124mpositional indexers are out-of-bounds\u001b[39m\u001b[38;5;124m\"\u001b[39m) \u001b[38;5;28;01mfrom\u001b[39;00m \u001b[38;5;21;01merr\u001b[39;00m\n",
+      "File \u001b[0;32m~/anaconda3/lib/python3.9/site-packages/pandas/core/generic.py:3716\u001b[0m, in \u001b[0;36mNDFrame._take_with_is_copy\u001b[0;34m(self, indices, axis)\u001b[0m\n\u001b[1;32m   3708\u001b[0m \u001b[38;5;28;01mdef\u001b[39;00m \u001b[38;5;21m_take_with_is_copy\u001b[39m(\u001b[38;5;28mself\u001b[39m: NDFrameT, indices, axis\u001b[38;5;241m=\u001b[39m\u001b[38;5;241m0\u001b[39m) \u001b[38;5;241m-\u001b[39m\u001b[38;5;241m>\u001b[39m NDFrameT:\n\u001b[1;32m   3709\u001b[0m \u001b[38;5;250m    \u001b[39m\u001b[38;5;124;03m\"\"\"\u001b[39;00m\n\u001b[1;32m   3710\u001b[0m \u001b[38;5;124;03m    Internal version of the `take` method that sets the `_is_copy`\u001b[39;00m\n\u001b[1;32m   3711\u001b[0m \u001b[38;5;124;03m    attribute to keep track of the parent dataframe (using in indexing\u001b[39;00m\n\u001b[0;32m   (...)\u001b[0m\n\u001b[1;32m   3714\u001b[0m \u001b[38;5;124;03m    See the docstring of `take` for full explanation of the parameters.\u001b[39;00m\n\u001b[1;32m   3715\u001b[0m \u001b[38;5;124;03m    \"\"\"\u001b[39;00m\n\u001b[0;32m-> 3716\u001b[0m     result \u001b[38;5;241m=\u001b[39m \u001b[38;5;28;43mself\u001b[39;49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43mtake\u001b[49m\u001b[43m(\u001b[49m\u001b[43mindices\u001b[49m\u001b[38;5;241;43m=\u001b[39;49m\u001b[43mindices\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[43maxis\u001b[49m\u001b[38;5;241;43m=\u001b[39;49m\u001b[43maxis\u001b[49m\u001b[43m)\u001b[49m\n\u001b[1;32m   3717\u001b[0m     \u001b[38;5;66;03m# Maybe set copy if we didn't actually change the index.\u001b[39;00m\n\u001b[1;32m   3718\u001b[0m     \u001b[38;5;28;01mif\u001b[39;00m \u001b[38;5;129;01mnot\u001b[39;00m result\u001b[38;5;241m.\u001b[39m_get_axis(axis)\u001b[38;5;241m.\u001b[39mequals(\u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39m_get_axis(axis)):\n",
+      "File \u001b[0;32m~/anaconda3/lib/python3.9/site-packages/pandas/core/generic.py:3703\u001b[0m, in \u001b[0;36mNDFrame.take\u001b[0;34m(self, indices, axis, is_copy, **kwargs)\u001b[0m\n\u001b[1;32m   3699\u001b[0m nv\u001b[38;5;241m.\u001b[39mvalidate_take((), kwargs)\n\u001b[1;32m   3701\u001b[0m \u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39m_consolidate_inplace()\n\u001b[0;32m-> 3703\u001b[0m new_data \u001b[38;5;241m=\u001b[39m \u001b[38;5;28;43mself\u001b[39;49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43m_mgr\u001b[49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43mtake\u001b[49m\u001b[43m(\u001b[49m\n\u001b[1;32m   3704\u001b[0m \u001b[43m    \u001b[49m\u001b[43mindices\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[43maxis\u001b[49m\u001b[38;5;241;43m=\u001b[39;49m\u001b[38;5;28;43mself\u001b[39;49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43m_get_block_manager_axis\u001b[49m\u001b[43m(\u001b[49m\u001b[43maxis\u001b[49m\u001b[43m)\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[43mverify\u001b[49m\u001b[38;5;241;43m=\u001b[39;49m\u001b[38;5;28;43;01mTrue\u001b[39;49;00m\n\u001b[1;32m   3705\u001b[0m \u001b[43m\u001b[49m\u001b[43m)\u001b[49m\n\u001b[1;32m   3706\u001b[0m \u001b[38;5;28;01mreturn\u001b[39;00m \u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39m_constructor(new_data)\u001b[38;5;241m.\u001b[39m__finalize__(\u001b[38;5;28mself\u001b[39m, method\u001b[38;5;241m=\u001b[39m\u001b[38;5;124m\"\u001b[39m\u001b[38;5;124mtake\u001b[39m\u001b[38;5;124m\"\u001b[39m)\n",
+      "File \u001b[0;32m~/anaconda3/lib/python3.9/site-packages/pandas/core/internals/managers.py:890\u001b[0m, in \u001b[0;36mBaseBlockManager.take\u001b[0;34m(self, indexer, axis, verify)\u001b[0m\n\u001b[1;32m    873\u001b[0m \u001b[38;5;250m\u001b[39m\u001b[38;5;124;03m\"\"\"\u001b[39;00m\n\u001b[1;32m    874\u001b[0m \u001b[38;5;124;03mTake items along any axis.\u001b[39;00m\n\u001b[1;32m    875\u001b[0m \n\u001b[0;32m   (...)\u001b[0m\n\u001b[1;32m    884\u001b[0m \u001b[38;5;124;03mBlockManager\u001b[39;00m\n\u001b[1;32m    885\u001b[0m \u001b[38;5;124;03m\"\"\"\u001b[39;00m\n\u001b[1;32m    886\u001b[0m \u001b[38;5;66;03m# We have 6 tests that get here with a slice\u001b[39;00m\n\u001b[1;32m    887\u001b[0m indexer \u001b[38;5;241m=\u001b[39m (\n\u001b[1;32m    888\u001b[0m     np\u001b[38;5;241m.\u001b[39marange(indexer\u001b[38;5;241m.\u001b[39mstart, indexer\u001b[38;5;241m.\u001b[39mstop, indexer\u001b[38;5;241m.\u001b[39mstep, dtype\u001b[38;5;241m=\u001b[39mnp\u001b[38;5;241m.\u001b[39mintp)\n\u001b[1;32m    889\u001b[0m     \u001b[38;5;28;01mif\u001b[39;00m \u001b[38;5;28misinstance\u001b[39m(indexer, \u001b[38;5;28mslice\u001b[39m)\n\u001b[0;32m--> 890\u001b[0m     \u001b[38;5;28;01melse\u001b[39;00m \u001b[43mnp\u001b[49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43masanyarray\u001b[49m\u001b[43m(\u001b[49m\u001b[43mindexer\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[43mdtype\u001b[49m\u001b[38;5;241;43m=\u001b[39;49m\u001b[43mnp\u001b[49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43mintp\u001b[49m\u001b[43m)\u001b[49m\n\u001b[1;32m    891\u001b[0m )\n\u001b[1;32m    893\u001b[0m n \u001b[38;5;241m=\u001b[39m \u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39mshape[axis]\n\u001b[1;32m    894\u001b[0m indexer \u001b[38;5;241m=\u001b[39m maybe_convert_indices(indexer, n, verify\u001b[38;5;241m=\u001b[39mverify)\n",
+      "File \u001b[0;32m~/anaconda3/lib/python3.9/site-packages/pandas/core/series.py:872\u001b[0m, in \u001b[0;36mSeries.__array__\u001b[0;34m(self, dtype)\u001b[0m\n\u001b[1;32m    825\u001b[0m \u001b[38;5;28;01mdef\u001b[39;00m \u001b[38;5;21m__array__\u001b[39m(\u001b[38;5;28mself\u001b[39m, dtype: npt\u001b[38;5;241m.\u001b[39mDTypeLike \u001b[38;5;241m|\u001b[39m \u001b[38;5;28;01mNone\u001b[39;00m \u001b[38;5;241m=\u001b[39m \u001b[38;5;28;01mNone\u001b[39;00m) \u001b[38;5;241m-\u001b[39m\u001b[38;5;241m>\u001b[39m np\u001b[38;5;241m.\u001b[39mndarray:\n\u001b[1;32m    826\u001b[0m \u001b[38;5;250m    \u001b[39m\u001b[38;5;124;03m\"\"\"\u001b[39;00m\n\u001b[1;32m    827\u001b[0m \u001b[38;5;124;03m    Return the values as a NumPy array.\u001b[39;00m\n\u001b[1;32m    828\u001b[0m \n\u001b[0;32m   (...)\u001b[0m\n\u001b[1;32m    870\u001b[0m \u001b[38;5;124;03m          dtype='datetime64[ns]')\u001b[39;00m\n\u001b[1;32m    871\u001b[0m \u001b[38;5;124;03m    \"\"\"\u001b[39;00m\n\u001b[0;32m--> 872\u001b[0m     \u001b[38;5;28;01mreturn\u001b[39;00m \u001b[43mnp\u001b[49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43masarray\u001b[49m\u001b[43m(\u001b[49m\u001b[38;5;28;43mself\u001b[39;49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43m_values\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[43mdtype\u001b[49m\u001b[43m)\u001b[49m\n",
+      "\u001b[0;31mValueError\u001b[0m: setting an array element with a sequence."
      ]
     }
    ],

--- a/example_notebook.ipynb
+++ b/example_notebook.ipynb
@@ -249,16 +249,28 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "ename": "AttributeError",
+     "evalue": "module 'etl_functions' has no attribute 'std_cols_names'",
+     "output_type": "error",
+     "traceback": [
+      "\u001b[0;31m---------------------------------------------------------------------------\u001b[0m",
+      "\u001b[0;31mAttributeError\u001b[0m                            Traceback (most recent call last)",
+      "Cell \u001b[0;32mIn[3], line 1\u001b[0m\n\u001b[0;32m----> 1\u001b[0m df_cmed \u001b[38;5;241m=\u001b[39m \u001b[43metl\u001b[49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43mstd_cols_names\u001b[49m(df_cmed)\n",
+      "\u001b[0;31mAttributeError\u001b[0m: module 'etl_functions' has no attribute 'std_cols_names'"
+     ]
+    }
+   ],
    "source": [
-    "df_cmed = etl.std_cols_names(df_cmed)"
+    "df_cmed = etl.std_cols_names_preprocessing(df_cmed)"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": null,
    "metadata": {},
    "outputs": [
     {
@@ -487,7 +499,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": null,
    "metadata": {},
    "outputs": [
     {
@@ -514,7 +526,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": null,
    "metadata": {},
    "outputs": [
     {
@@ -736,7 +748,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": null,
    "metadata": {},
    "outputs": [
     {
@@ -774,7 +786,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": null,
    "metadata": {},
    "outputs": [
     {
@@ -935,7 +947,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": null,
    "metadata": {},
    "outputs": [
     {
@@ -957,7 +969,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": null,
    "metadata": {},
    "outputs": [
     {
@@ -985,7 +997,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -994,7 +1006,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
+   "execution_count": null,
    "metadata": {},
    "outputs": [
     {
@@ -1179,7 +1191,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1188,7 +1200,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 15,
+   "execution_count": null,
    "metadata": {},
    "outputs": [
     {
@@ -1344,7 +1356,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 16,
+   "execution_count": null,
    "metadata": {},
    "outputs": [
     {
@@ -1387,7 +1399,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 17,
+   "execution_count": null,
    "metadata": {},
    "outputs": [
     {
@@ -1590,7 +1602,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 19,
+   "execution_count": null,
    "metadata": {},
    "outputs": [
     {
@@ -1783,7 +1795,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 20,
+   "execution_count": null,
    "metadata": {},
    "outputs": [
     {

--- a/example_notebook.ipynb
+++ b/example_notebook.ipynb
@@ -249,7 +249,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": 3,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -258,7 +258,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": 4,
    "metadata": {},
    "outputs": [
     {
@@ -462,7 +462,7 @@
        "[29866 rows x 8 columns]"
       ]
      },
-     "execution_count": 5,
+     "execution_count": 4,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -487,21 +487,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": 5,
    "metadata": {},
    "outputs": [
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "0it [00:00, ?it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "29866it [00:09, 3215.70it/s]\n"
+      "29866it [00:08, 3442.48it/s]\n"
      ]
     }
    ],
@@ -521,7 +514,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": 6,
    "metadata": {},
    "outputs": [
     {
@@ -725,7 +718,7 @@
        "[29866 rows x 8 columns]"
       ]
      },
-     "execution_count": 7,
+     "execution_count": 6,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -743,14 +736,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": 7,
    "metadata": {},
    "outputs": [
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "Grouping active ingredients: 100%|██████████| 2140/2140 [00:05<00:00, 391.57it/s]\n"
+      "Grouping active ingredients: 100%|██████████| 2140/2140 [00:05<00:00, 404.04it/s]\n"
      ]
     }
    ],
@@ -760,7 +753,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": 8,
    "metadata": {},
    "outputs": [
     {
@@ -891,7 +884,7 @@
        "[2072 rows x 3 columns]"
       ]
      },
-     "execution_count": 10,
+     "execution_count": 8,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -909,7 +902,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": 9,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -921,7 +914,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": 10,
    "metadata": {},
    "outputs": [
     {
@@ -931,7 +924,7 @@
        "       'zuclopentixol'], dtype='<U30')"
       ]
      },
-     "execution_count": 12,
+     "execution_count": 10,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -943,7 +936,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
+   "execution_count": 11,
    "metadata": {},
    "outputs": [
     {
@@ -952,7 +945,7 @@
        "array(['0', '00', '000', ..., 'xamp', 'xpe', 'xpect'], dtype='<U16')"
       ]
      },
-     "execution_count": 13,
+     "execution_count": 11,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -971,7 +964,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
+   "execution_count": 12,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -980,7 +973,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 15,
+   "execution_count": 13,
    "metadata": {},
    "outputs": [
     {
@@ -1147,7 +1140,7 @@
        "[199 rows x 6 columns]"
       ]
      },
-     "execution_count": 15,
+     "execution_count": 13,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1165,7 +1158,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 16,
+   "execution_count": 14,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1174,7 +1167,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 17,
+   "execution_count": 15,
    "metadata": {},
    "outputs": [
     {
@@ -1305,7 +1298,7 @@
        "[199 rows x 3 columns]"
       ]
      },
-     "execution_count": 17,
+     "execution_count": 15,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1330,7 +1323,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 18,
+   "execution_count": 16,
    "metadata": {},
    "outputs": [
     {
@@ -1344,7 +1337,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "199it [00:00, 1150.26it/s]\n"
+      "199it [00:00, 1213.88it/s]\n"
      ]
     }
    ],
@@ -1373,7 +1366,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 19,
+   "execution_count": 17,
    "metadata": {},
    "outputs": [
     {
@@ -1528,7 +1521,7 @@
        "[199 rows x 5 columns]"
       ]
      },
-     "execution_count": 19,
+     "execution_count": 17,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1546,7 +1539,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 20,
+   "execution_count": 18,
    "metadata": {},
    "outputs": [
     {
@@ -1554,6 +1547,22 @@
      "output_type": "stream",
      "text": [
       "0it [00:00, ?it/s]\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "20    [532, 533, 534, 535, 536, 537, 538, 539, 540, ...\n",
+      "Name: indexes, dtype: object\n",
+      "[532 533 534 535 536 537 538 539 540 541 542 543 544 545 546 547 548 549\n",
+      " 550 551 552 553 554 555 556 557 558 559 560 561 562 563 564 565 566 567\n",
+      " 568 569 570 571 572 573 574 575 576 577 578 579 580 581 582 583 584 585\n",
+      " 586 587 588 589 590 591 592 593 594 595 596 597 598 599 600 601 602 603\n",
+      " 604 605 606 607 608 609 610 611 612 613 614 615 616 617 618 619 620 621\n",
+      " 622 623 624 625 626 627 628 629 630 631 632 633 634 635 636 637 638 639\n",
+      " 640 641 642 643 644 645 646 647 648 649 650 651 652 653 654 655 656 657\n",
+      " 658 659 660 661 662 663 664]\n"
      ]
     },
     {
@@ -1566,8 +1575,8 @@
       "\u001b[0;31mTypeError\u001b[0m: only size-1 arrays can be converted to Python scalars",
       "\nThe above exception was the direct cause of the following exception:\n",
       "\u001b[0;31mValueError\u001b[0m                                Traceback (most recent call last)",
-      "Cell \u001b[0;32mIn[20], line 10\u001b[0m\n\u001b[1;32m      7\u001b[0m desc_ai, desc_pr \u001b[38;5;241m=\u001b[39m ir_med\u001b[38;5;241m.\u001b[39msplit_description(row_X[\u001b[38;5;124m'\u001b[39m\u001b[38;5;124mdesc\u001b[39m\u001b[38;5;124m'\u001b[39m], cmed_ai_words, cmed_pr_words)\n\u001b[1;32m      9\u001b[0m \u001b[38;5;66;03m# Função de classificação\u001b[39;00m\n\u001b[0;32m---> 10\u001b[0m df_notice\u001b[38;5;241m.\u001b[39mat[idx_X, \u001b[38;5;124m'\u001b[39m\u001b[38;5;124mcmed_indexes\u001b[39m\u001b[38;5;124m'\u001b[39m], process_metadata \u001b[38;5;241m=\u001b[39m \u001b[43mir_med\u001b[49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43mpredict\u001b[49m\u001b[43m(\u001b[49m\u001b[43mdf_cmed\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[43mgrouped_cmed\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[43mdesc_ai\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[43mdesc_pr\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[43mrow_X\u001b[49m\u001b[43m[\u001b[49m\u001b[38;5;124;43m'\u001b[39;49m\u001b[38;5;124;43mund\u001b[39;49m\u001b[38;5;124;43m'\u001b[39;49m\u001b[43m]\u001b[49m\u001b[43m)\u001b[49m\n\u001b[1;32m     12\u001b[0m \u001b[38;5;28;01mif\u001b[39;00m SAVE_PROCESS_METADATA:\n\u001b[1;32m     13\u001b[0m     \u001b[38;5;28;01mfor\u001b[39;00m key, value \u001b[38;5;129;01min\u001b[39;00m process_metadata\u001b[38;5;241m.\u001b[39mitems():\n",
-      "File \u001b[0;32m~/Documentos/Code/ir-med/ir_med.py:119\u001b[0m, in \u001b[0;36mpredict\u001b[0;34m(df_cmed, grouped_cmed, desc_ai, desc_pr, und)\u001b[0m\n\u001b[1;32m    117\u001b[0m \u001b[38;5;66;03m# Colect medicines that have the active ingredient\u001b[39;00m\n\u001b[1;32m    118\u001b[0m idxs \u001b[38;5;241m=\u001b[39m grouped_cmed\u001b[38;5;241m.\u001b[39mloc[grouped_cmed[\u001b[38;5;124m'\u001b[39m\u001b[38;5;124mkey\u001b[39m\u001b[38;5;124m'\u001b[39m] \u001b[38;5;241m==\u001b[39m ai_found, \u001b[38;5;124m'\u001b[39m\u001b[38;5;124mindexes\u001b[39m\u001b[38;5;124m'\u001b[39m]\n\u001b[0;32m--> 119\u001b[0m df_cmed_filtered \u001b[38;5;241m=\u001b[39m \u001b[43mdf_cmed\u001b[49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43miloc\u001b[49m\u001b[43m[\u001b[49m\u001b[43midxs\u001b[49m\u001b[43m]\u001b[49m\n\u001b[1;32m    121\u001b[0m \u001b[38;5;66;03m# Filter medicines based on the pharmaceutical presentation\u001b[39;00m\n\u001b[1;32m    122\u001b[0m best_matches, filter_prs_metadata \u001b[38;5;241m=\u001b[39m filter_prs(df_cmed_filtered, desc_ai,\n\u001b[1;32m    123\u001b[0m                                              desc_pr, und, ai_found)\n",
+      "Cell \u001b[0;32mIn[18], line 10\u001b[0m\n\u001b[1;32m      7\u001b[0m desc_ai, desc_pr \u001b[38;5;241m=\u001b[39m ir_med\u001b[38;5;241m.\u001b[39msplit_description(row_X[\u001b[38;5;124m'\u001b[39m\u001b[38;5;124mdesc\u001b[39m\u001b[38;5;124m'\u001b[39m], cmed_ai_words, cmed_pr_words)\n\u001b[1;32m      9\u001b[0m \u001b[38;5;66;03m# Função de classificação\u001b[39;00m\n\u001b[0;32m---> 10\u001b[0m df_notice\u001b[38;5;241m.\u001b[39mat[idx_X, \u001b[38;5;124m'\u001b[39m\u001b[38;5;124mcmed_indexes\u001b[39m\u001b[38;5;124m'\u001b[39m], process_metadata \u001b[38;5;241m=\u001b[39m \u001b[43mir_med\u001b[49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43mpredict\u001b[49m\u001b[43m(\u001b[49m\u001b[43mdf_cmed\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[43mgrouped_cmed\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[43mdesc_ai\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[43mdesc_pr\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[43mrow_X\u001b[49m\u001b[43m[\u001b[49m\u001b[38;5;124;43m'\u001b[39;49m\u001b[38;5;124;43mund\u001b[39;49m\u001b[38;5;124;43m'\u001b[39;49m\u001b[43m]\u001b[49m\u001b[43m)\u001b[49m\n\u001b[1;32m     12\u001b[0m \u001b[38;5;28;01mif\u001b[39;00m SAVE_PROCESS_METADATA:\n\u001b[1;32m     13\u001b[0m     \u001b[38;5;28;01mfor\u001b[39;00m key, value \u001b[38;5;129;01min\u001b[39;00m process_metadata\u001b[38;5;241m.\u001b[39mitems():\n",
+      "File \u001b[0;32m~/Documentos/Code/ir-med/ir_med.py:121\u001b[0m, in \u001b[0;36mpredict\u001b[0;34m(df_cmed, grouped_cmed, desc_ai, desc_pr, und)\u001b[0m\n\u001b[1;32m    119\u001b[0m \u001b[38;5;28mprint\u001b[39m(idxs)\n\u001b[1;32m    120\u001b[0m \u001b[38;5;28mprint\u001b[39m(idxs\u001b[38;5;241m.\u001b[39mvalues[\u001b[38;5;241m0\u001b[39m])\n\u001b[0;32m--> 121\u001b[0m df_cmed_filtered \u001b[38;5;241m=\u001b[39m \u001b[43mdf_cmed\u001b[49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43miloc\u001b[49m\u001b[43m[\u001b[49m\u001b[43midxs\u001b[49m\u001b[43m]\u001b[49m\n\u001b[1;32m    123\u001b[0m \u001b[38;5;66;03m# Filter medicines based on the pharmaceutical presentation\u001b[39;00m\n\u001b[1;32m    124\u001b[0m best_matches, filter_prs_metadata \u001b[38;5;241m=\u001b[39m filter_prs(df_cmed_filtered, desc_ai,\n\u001b[1;32m    125\u001b[0m                                              desc_pr, und, ai_found)\n",
       "File \u001b[0;32m~/anaconda3/lib/python3.9/site-packages/pandas/core/indexing.py:967\u001b[0m, in \u001b[0;36m_LocationIndexer.__getitem__\u001b[0;34m(self, key)\u001b[0m\n\u001b[1;32m    964\u001b[0m axis \u001b[38;5;241m=\u001b[39m \u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39maxis \u001b[38;5;129;01mor\u001b[39;00m \u001b[38;5;241m0\u001b[39m\n\u001b[1;32m    966\u001b[0m maybe_callable \u001b[38;5;241m=\u001b[39m com\u001b[38;5;241m.\u001b[39mapply_if_callable(key, \u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39mobj)\n\u001b[0;32m--> 967\u001b[0m \u001b[38;5;28;01mreturn\u001b[39;00m \u001b[38;5;28;43mself\u001b[39;49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43m_getitem_axis\u001b[49m\u001b[43m(\u001b[49m\u001b[43mmaybe_callable\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[43maxis\u001b[49m\u001b[38;5;241;43m=\u001b[39;49m\u001b[43maxis\u001b[49m\u001b[43m)\u001b[49m\n",
       "File \u001b[0;32m~/anaconda3/lib/python3.9/site-packages/pandas/core/indexing.py:1514\u001b[0m, in \u001b[0;36m_iLocIndexer._getitem_axis\u001b[0;34m(self, key, axis)\u001b[0m\n\u001b[1;32m   1512\u001b[0m \u001b[38;5;66;03m# a list of integers\u001b[39;00m\n\u001b[1;32m   1513\u001b[0m \u001b[38;5;28;01melif\u001b[39;00m is_list_like_indexer(key):\n\u001b[0;32m-> 1514\u001b[0m     \u001b[38;5;28;01mreturn\u001b[39;00m \u001b[38;5;28;43mself\u001b[39;49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43m_get_list_axis\u001b[49m\u001b[43m(\u001b[49m\u001b[43mkey\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[43maxis\u001b[49m\u001b[38;5;241;43m=\u001b[39;49m\u001b[43maxis\u001b[49m\u001b[43m)\u001b[49m\n\u001b[1;32m   1516\u001b[0m \u001b[38;5;66;03m# a single integer\u001b[39;00m\n\u001b[1;32m   1517\u001b[0m \u001b[38;5;28;01melse\u001b[39;00m:\n\u001b[1;32m   1518\u001b[0m     key \u001b[38;5;241m=\u001b[39m item_from_zerodim(key)\n",
       "File \u001b[0;32m~/anaconda3/lib/python3.9/site-packages/pandas/core/indexing.py:1485\u001b[0m, in \u001b[0;36m_iLocIndexer._get_list_axis\u001b[0;34m(self, key, axis)\u001b[0m\n\u001b[1;32m   1468\u001b[0m \u001b[38;5;250m\u001b[39m\u001b[38;5;124;03m\"\"\"\u001b[39;00m\n\u001b[1;32m   1469\u001b[0m \u001b[38;5;124;03mReturn Series values by list or array of integers.\u001b[39;00m\n\u001b[1;32m   1470\u001b[0m \n\u001b[0;32m   (...)\u001b[0m\n\u001b[1;32m   1482\u001b[0m \u001b[38;5;124;03m`axis` can only be zero.\u001b[39;00m\n\u001b[1;32m   1483\u001b[0m \u001b[38;5;124;03m\"\"\"\u001b[39;00m\n\u001b[1;32m   1484\u001b[0m \u001b[38;5;28;01mtry\u001b[39;00m:\n\u001b[0;32m-> 1485\u001b[0m     \u001b[38;5;28;01mreturn\u001b[39;00m \u001b[38;5;28;43mself\u001b[39;49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43mobj\u001b[49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43m_take_with_is_copy\u001b[49m\u001b[43m(\u001b[49m\u001b[43mkey\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[43maxis\u001b[49m\u001b[38;5;241;43m=\u001b[39;49m\u001b[43maxis\u001b[49m\u001b[43m)\u001b[49m\n\u001b[1;32m   1486\u001b[0m \u001b[38;5;28;01mexcept\u001b[39;00m \u001b[38;5;167;01mIndexError\u001b[39;00m \u001b[38;5;28;01mas\u001b[39;00m err:\n\u001b[1;32m   1487\u001b[0m     \u001b[38;5;66;03m# re-raise with different error message\u001b[39;00m\n\u001b[1;32m   1488\u001b[0m     \u001b[38;5;28;01mraise\u001b[39;00m \u001b[38;5;167;01mIndexError\u001b[39;00m(\u001b[38;5;124m\"\u001b[39m\u001b[38;5;124mpositional indexers are out-of-bounds\u001b[39m\u001b[38;5;124m\"\u001b[39m) \u001b[38;5;28;01mfrom\u001b[39;00m \u001b[38;5;21;01merr\u001b[39;00m\n",

--- a/example_notebook.ipynb
+++ b/example_notebook.ipynb
@@ -1560,7 +1560,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 18,
+   "execution_count": null,
    "metadata": {},
    "outputs": [
     {
@@ -1578,7 +1578,7 @@
     "\n",
     "for idx_X, row_X in tqdm(df_notice.iterrows()):\n",
     "\n",
-    "    desc_ai, desc_pr = ir_med.sep_desc(row_X['desc'], cmed_ai_words, cmed_pr_words)\n",
+    "    desc_ai, desc_pr = ir_med.split_description(row_X['desc'], cmed_ai_words, cmed_pr_words)\n",
     "\n",
     "    # Função de classificação\n",
     "    df_notice.at[idx_X, 'cmed_indexes'], process_metadata = ir_med.predict(df_cmed, grouped_cmed, desc_ai, desc_pr, row_X['und'])\n",

--- a/example_notebook.ipynb
+++ b/example_notebook.ipynb
@@ -923,14 +923,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
     "import ir_med\n",
     "\n",
-    "answer_dict = ir_med.extract_relevant_words(df_cmed,\n",
-    "                                            columns=['substancia', 'apresentacao'])"
+    "answer_dict = ir_med.identify_relevant_words(df_cmed,\n",
+    "                                             columns=['substancia', 'apresentacao'])"
    ]
   },
   {

--- a/ir_med.py
+++ b/ir_med.py
@@ -5,8 +5,7 @@ from jaro import jaro_winkler_metric
 from nltk.tokenize import word_tokenize
 from tqdm import tqdm
 
-
-def extract_relevant_words(df_cmed, columns, verbose = False):
+def identify_relevant_words(df_cmed, columns, verbose = False):
     """
     Extracts tokens (words) from the specified columns of a DataFrame.
 

--- a/ir_med.py
+++ b/ir_med.py
@@ -6,25 +6,6 @@ from nltk.tokenize import word_tokenize
 from tqdm import tqdm
 
 
-def template():
-    """
-    Breve descrição da função
-    
-    Parameters:
-    ---------
-    {parameter_name} : {parameter_type}[, default ?]
-        {Parameter description}
-
-    {parameter_name} : {parameter_type}[, default ?]
-        {Parameter description}
-
-    Returns:
-    ---------
-    {return_type}
-        {Return description}
-    """
-    return -1
-
 def extract_relevant_words(df_cmed, columns, verbose = False):
     """
     Extracts tokens (words) from the specified columns of a DataFrame.

--- a/ir_med.py
+++ b/ir_med.py
@@ -76,26 +76,25 @@ def split_description(desc, cmed_ai_words, cmed_pr_words):
 
 def predict(df_cmed, grouped_cmed, desc_ai, desc_pr, und):
     """
-    Runs the complete medicine identification process based on a public notice
-    description.
+    Run the complete medicine identification process based on a description from
+    a public notice.
 
     Parameters
     ----------
     df_cmed : DataFrame
-        DataFrame containing the CMED data.
+        DataFrame containing the CMED dataset.
 
     grouped_cmed : DataFrame
         DataFrame containing grouped CMED data.
 
     desc_ai : str
-        Description related to the active ingredient from the public notice.
+        Portion of the description related to the active ingredient.
 
     desc_pr : str
-        Description related to the pharmaceutical presentation from the public
-        notice.
+        Portion of the description related to the pharmaceutical presentation.
 
     und : str
-        Unit description from the 'unidade' column in the notice data.
+        Unit of measurement specified in the public notice.
 
     Returns
     -------
@@ -104,20 +103,30 @@ def predict(df_cmed, grouped_cmed, desc_ai, desc_pr, und):
         - list of int: Indices of the best matching presentations in the CMED data.
         - dict: Metadata about the identification process, including:
             - 'desc_ai': Active ingredient description used for matching.
+            - 'active_ingredient_found': The matched active ingredient.
+            - 'similarity_value': Similarity score of the best active ingredient match.
             - 'desc_pr': Pharmaceutical presentation description used for matching.
-            - 'active_ingredient_found': The active ingredient that was matched.
-            - 'quant_presentations_matched': Number of matching presentations.
             - 'size_cmed_filtered': Number of rows in the filtered CMED DataFrame.
-            - 'pct_set_reduction': Percentage reduction in the CMED dataset after filtering.
+            - 'quant_presentations_matched': Number of matching presentations.
+            - 'pct_set_reduction': Percentage reduction in CMED entries after filtering.
     """
 
     # Classification of the active_ingredient
-    active_ingredient, _ = match_ai(grouped_cmed, desc_ai)
+    ai_found, match_ai_metadata = match_ai(grouped_cmed, desc_ai)
 
-    # Coleta dos medicamentos da CMED que possuem o principio ativo apontado
-    df_cmed_filtered = df_cmed.iloc[grouped_cmed[grouped_cmed['key'] == active_ingredient].reset_index()['indexes'][0]]
+    # Colect medicines that have the active ingredient
+    idxs = grouped_cmed.loc[grouped_cmed['key'] == ai_found, 'indexes']
+    df_cmed_filtered = df_cmed.iloc[idxs]
+
+    # Filter medicines based on the pharmaceutical presentation
+    best_matches, filter_prs_metadata = filter_prs(df_cmed_filtered, desc_ai,
+                                                 desc_pr, und, ai_found)
     
-    return filter_prs(df_cmed_filtered, desc_ai, desc_pr, und, active_ingredient)
+    # Create process metadata for the whole matching process
+    process_metadata = match_ai_metadata
+    process_metadata.update(filter_prs_metadata)
+
+    return best_matches, process_metadata
 
 def match_ai(grouped_cmed, desc_ai):
     """
@@ -193,8 +202,8 @@ def filter_prs(df_cmed_filtered, desc_ai, desc_pr, und, active_ingredient):
             - 'desc_ai': Active ingredient description used for matching.
             - 'desc_pr': Pharmaceutical presentation description used for matching.
             - 'active_ingredient_found': The active ingredient that was matched.
-            - 'quant_presentations_matched': Number of matching presentations.
             - 'size_cmed_filtered': Number of rows in the filtered CMED DataFrame.
+            - 'quant_presentations_matched': Number of matching presentations.
             - 'pct_set_reduction': Percentage reduction in the CMED dataset after filtering.
     """
 

--- a/ir_med.py
+++ b/ir_med.py
@@ -43,10 +43,10 @@ def identify_relevant_words(df_cmed, columns, verbose = False):
 
     return answer_dict
 
-def sep_desc(desc, cmed_ai_words, cmed_pr_words):
+def split_description(desc, cmed_ai_words, cmed_pr_words):
     """
-    Extracts words from a notice description that match entries in the CMED
-    report.
+    Extract words from a medicine description that match tokens identified in
+    the CMED dataset.
 
     Parameters
     ----------
@@ -54,33 +54,25 @@ def sep_desc(desc, cmed_ai_words, cmed_pr_words):
         Description of a medicine from the public notice.
 
     cmed_ai_words : list of str
-        List of words representing active ingredients from the CMED report.
+        List of tokens identified as active ingredients in the CMED dataset.
 
     cmed_pr_words : list of str
-        List of words representing pharmaceutical presentations from the CMED
-        report.
+        List of tokens identified as pharmaceutical presentations in the CMED
+        dataset.
 
     Returns
     -------
     tuple of str
-        A tuple containing two strings:
-        - The first string includes words from the description that match active
-          ingredient terms.
-        - The second string includes words that match pharmaceutical
-          presentation terms.
+        A tuple containing:
+        - A string with the words from the description that match active ingredient terms.
+        - A string with the words from the description that match pharmaceutical presentation terms.
     """
 
-    desc_ai = ""
-    desc_pr = ""
-
-    for tok in word_tokenize(desc):
-        if tok in cmed_ai_words:
-            desc_ai += tok + " "
+    tokens = word_tokenize(desc)
+    desc_ai = " ".join([tok for tok in tokens if tok in cmed_ai_words])
+    desc_pr = " ".join([tok for tok in tokens if tok in cmed_pr_words])
         
-        if tok in cmed_pr_words:
-            desc_pr += tok + " "
-        
-    return (desc_ai, desc_pr)
+    return desc_ai, desc_pr
 
 def predict(df_cmed, grouped_cmed, desc_ai, desc_pr, und):
     """

--- a/ir_med.py
+++ b/ir_med.py
@@ -208,7 +208,7 @@ def match_presentations(df_cmed_filtered, desc_pr, und):
             - 'pct_set_reduction' (float): Percentage reduction in CMED entries after filtering.
     """
 
-    sets = get_sets_from_desc_pr(desc_pr) + get_sets_from_desc_pr(und)
+    sets = extract_ngrams(desc_pr) + extract_ngrams(und)
     best_count = 0
     best_matchs = []
 
@@ -255,46 +255,28 @@ def match_presentations(df_cmed_filtered, desc_pr, und):
 
 
 
-def get_sets_from_desc_pr(desc_pr):
+def extract_ngrams(desc_pr):
     """
-    Generates all possible sets of words from a given description.
+    Extracts all contiguous sequences of words (n-grams) from a given
+    pharmaceutical presentation description.
 
     Parameters
     ----------
     desc_pr : str
-        Description related to the pharmaceutical presentation from the public
-        notice.
+        Substring of the public notice description related to the pharmaceutical
+        presentation.
 
     Returns
     -------
     list of list of str
-        A list containing all possible combinations of words extracted from the
-        description.
+        A list where each sublist represents a contiguous sequence of words
+        (n-gram) extracted from the input description.
     """
     tokens = word_tokenize(desc_pr)
     n_tokens = len(tokens)
 
-    func = lambda x : (x**2 + x) / 2    # Calculate the number of sets to create
-    quant_verificacoes = int(func(n_tokens))
-
-    sets = []
-    subset_size = 1
-    reduction_value = 0
-
-    for i in range(quant_verificacoes):
-        x = i - reduction_value
-        
-        match = (n_tokens - subset_size + 1)
-
-        if x >= match:
-            x -= (n_tokens - subset_size + 1)
-            reduction_value += (n_tokens - subset_size + 1)
-            subset_size += 1
-
-        st = []
-        for j in range(subset_size):
-            st.append(tokens[x+j])
-
-        sets.append(st)
+    sets = [tokens[start_index : start_index + slice_range] \
+            for slice_range in range(1, n_tokens + 1) \
+                for start_index in range(n_tokens - slice_range + 1)]
 
     return sets

--- a/ir_med.py
+++ b/ir_med.py
@@ -1,5 +1,4 @@
 import etl_functions as etl
-# import math
 import numpy as np
 from jaro import jaro_winkler_metric
 from nltk.tokenize import word_tokenize
@@ -76,22 +75,24 @@ def split_description(desc, cmed_ai_words, cmed_pr_words):
 
 def predict(df_cmed, grouped_cmed, desc_ai, desc_pr, und):
     """
-    Run the complete medicine identification process based on a description from
-    a public notice.
+    Runs the complete medicine identification process based on a description
+    from a public notice.
 
     Parameters
     ----------
-    df_cmed : DataFrame
+    df_cmed : pandas.DataFrame
         DataFrame containing the CMED dataset.
 
-    grouped_cmed : DataFrame
-        DataFrame containing grouped CMED data.
+    grouped_cmed : pandas.DataFrame
+        DataFrame containing CMED data grouped by active ingredient.
 
     desc_ai : str
-        Portion of the description related to the active ingredient.
+        Substring of the public notice description related to the active
+        ingredient.
 
     desc_pr : str
-        Portion of the description related to the pharmaceutical presentation.
+        Substring of the public notice description related to the pharmaceutical
+        presentation.
 
     und : str
         Unit of measurement specified in the public notice.
@@ -100,15 +101,16 @@ def predict(df_cmed, grouped_cmed, desc_ai, desc_pr, und):
     -------
     tuple
         A tuple containing:
+        
         - list of int: Indices of the best matching presentations in the CMED data.
         - dict: Metadata about the identification process, including:
-            - 'desc_ai': Active ingredient description used for matching.
-            - 'active_ingredient_found': The matched active ingredient.
-            - 'similarity_value': Similarity score of the best active ingredient match.
-            - 'desc_pr': Pharmaceutical presentation description used for matching.
-            - 'size_cmed_filtered': Number of rows in the filtered CMED DataFrame.
-            - 'quant_presentations_matched': Number of matching presentations.
-            - 'pct_set_reduction': Percentage reduction in CMED entries after filtering.
+            - 'active_ingredient_found' (str): The matched active ingredient.
+            - 'desc_ai' (str): Active ingredient description used for matching.
+            - 'similarity_value' (float): Similarity score of the best active ingredient match.
+            - 'desc_pr' (str): Pharmaceutical presentation description used for matching.
+            - 'len_cmed_filtered' (int): Number of rows in the filtered CMED DataFrame.
+            - 'len_best_matches' (int): Number of matching presentations after filtering.
+            - 'pct_set_reduction' (float): Percentage reduction in CMED entries after filtering.
     """
 
     # Classification of the active_ingredient
@@ -119,12 +121,15 @@ def predict(df_cmed, grouped_cmed, desc_ai, desc_pr, und):
     df_cmed_filtered = df_cmed.iloc[idxs.values[0]]
 
     # Filter medicines based on the pharmaceutical presentation
-    best_matches, filter_prs_metadata = filter_prs(df_cmed_filtered, desc_ai,
-                                                 desc_pr, und, ai_found)
+    best_matches, match_presentations_metadata = match_presentations(df_cmed_filtered,
+                                                                     desc_ai,
+                                                                     desc_pr,
+                                                                     und, ai_found)
     
     # Create process metadata for the whole matching process
-    process_metadata = predict_ai_metadata
-    process_metadata.update(filter_prs_metadata)
+    process_metadata = {'active_ingredient_found': ai_found}
+    process_metadata.update(predict_ai_metadata)
+    process_metadata.update(match_presentations_metadata)
 
     return best_matches, process_metadata
 
@@ -147,8 +152,8 @@ def predict_ai(grouped_cmed, desc_ai):
         A tuple containing:
         - str: The best matching active ingredient key.
         - dict: Metadata about the matching process, including:
-            - 'desc_ai': The description used for matching.
-            - 'similarity_value': Similarity score of the best match.
+            - 'desc_ai' (str): Active ingredient description used for matching.
+            - 'similarity_value' (float): Similarity score of the best active ingredient match.
     """
 
     # Sort the description alphabetically
@@ -170,28 +175,26 @@ def predict_ai(grouped_cmed, desc_ai):
 
     return best_match_key, process_metadata
 
-def filter_prs(df_cmed_filtered, desc_ai, desc_pr, und, active_ingredient):
+def match_presentations(df_cmed_filtered, desc_pr, und):
     """
-    Function that returns the presentations that have the most intersection with
-    desc_pr
+    Identifies entries in the CMED DataFrame whose pharmaceutical presentations 
+    best match the presentation description provided in the public notice.
+
+    This function operates on CMED data already filtered by an active
+    ingredient.
     
     Parameters:
     ---------
     df_cmed_filtered : DataFrame
-        DataFrame containing the filtered CMED data based on the active ingredient.
-
-    desc_ai : str
-        Description related to the active ingredient from the public notice.
+        DataFrame containing the filtered CMED data based on the active
+        ingredient.
     
     desc_pr : str
-        Description related to the pharmaceutical presentation from the public
-        notice.
+        Substring of the public notice description related to the pharmaceutical
+        presentation.
     
     und : str
-        Unit description from the 'unidade' column in the notice data.
-    
-    active_ingredient : str
-        The active ingredient that was matched from the CMED data.
+        Unit of measurement specified in the public notice.
 
     Returns:
     ---------
@@ -199,66 +202,58 @@ def filter_prs(df_cmed_filtered, desc_ai, desc_pr, und, active_ingredient):
         A tuple containing:
         - list of int: Indices of the best matching presentations in the CMED data.
         - dict: Metadata about the identification process, including:
-            - 'desc_ai': Active ingredient description used for matching.
-            - 'desc_pr': Pharmaceutical presentation description used for matching.
-            - 'active_ingredient_found': The active ingredient that was matched.
-            - 'size_cmed_filtered': Number of rows in the filtered CMED DataFrame.
-            - 'quant_presentations_matched': Number of matching presentations.
-            - 'pct_set_reduction': Percentage reduction in the CMED dataset after filtering.
+            - 'desc_pr' (str): Pharmaceutical presentation description used for matching.
+            - 'len_cmed_filtered' (int): Number of rows in the filtered CMED DataFrame.
+            - 'len_best_matches' (int): Number of matching presentations after filtering.
+            - 'pct_set_reduction' (float): Percentage reduction in CMED entries after filtering.
     """
 
-    sets = get_sets_from_desc_pr(desc_pr)
-    und_sets = get_sets_from_desc_pr(und)
-    sets.extend(und_sets)
-
+    sets = get_sets_from_desc_pr(desc_pr) + get_sets_from_desc_pr(und)
     best_count = 0
     best_matchs = []
 
-    for idx_cmed, row_cmed in df_cmed_filtered.iterrows():
+    # Pre-tokenize presentations in the CMED DataFrame
+    presentations_tokenized = df_cmed_filtered['apresentacao'] \
+                              .map(word_tokenize)
 
-        # Check if the presetation has the tokens found in the notice entry
+    for idx_cmed, tokens_cmed in presentations_tokenized.items():
         count = 0
-        tokens_cmed = word_tokenize(row_cmed['apresentacao'])
 
-        for st in sets:
-            
-            # If set only has one token, check if that tokens appears in the CMED presentation
+        for st in sets:            
+            # If set only has one token, check if that tokens appears in the
+            # CMED presentation
             if len(st) == 1:
                 if st[0] in tokens_cmed:
                     count += 1
 
-            # If set has more than a token, check if the sequence of tokens appears, in that order, in the CMED presentation
+            # If set has more than a token, check if the sequence of tokens
+            # appears, in that order, in the CMED presentation
             else:
-                if st[0] in tokens_cmed:
-                    check = True
-                    initial_index = tokens_cmed.index(st[0])
-                    
-                    for i in range(1, len(st)):
-                        current_index = (i+initial_index)
-                        
-                        if (current_index >= len(tokens_cmed)) or \
-                            (st[i] != tokens_cmed[current_index]):
+                window_range = len(tokens_cmed) - len(st) + 1
 
-                            check = False
-                            break
-                                
-                    if check:
+                for i in range(window_range):
+                    if tokens_cmed[i:i+len(st)] == st:
                         count += 1
+                        break
 
         if count > best_count:
             best_count = count
             best_matchs = [idx_cmed]
+
         elif count == best_count:
             best_matchs.append(idx_cmed)
 
-    process_metadata = {'desc_ai': desc_ai,
-                        'desc_pr': desc_pr,
-                        'active_ingredient_found': active_ingredient,
-                        'quant_presentations_matched': len(best_matchs),
-                        'size_cmed_filtered': len(df_cmed_filtered),
-                        'pct_set_reduction': (1 - (len(best_matchs) / len(df_cmed_filtered)))}
+    process_metadata = {
+        'desc_pr': desc_pr,
+        'quant_presentations_matched': len(best_matchs),
+        'size_cmed_filtered': len(df_cmed_filtered),
+        'pct_set_reduction': (1 - (len(best_matchs) / len(df_cmed_filtered))) \
+                             if len(df_cmed_filtered) else 1.0
+    }
 
-    return (best_matchs, process_metadata)
+    return best_matchs, process_metadata
+
+
 
 def get_sets_from_desc_pr(desc_pr):
     """

--- a/ir_med.py
+++ b/ir_med.py
@@ -112,7 +112,7 @@ def predict(df_cmed, grouped_cmed, desc_ai, desc_pr, und):
     """
 
     # Classification of the active_ingredient
-    ai_found, match_ai_metadata = match_ai(grouped_cmed, desc_ai)
+    ai_found, predict_ai_metadata = predict_ai(grouped_cmed, desc_ai)
 
     # Colect medicines that have the active ingredient
     idxs = grouped_cmed.loc[grouped_cmed['key'] == ai_found, 'indexes']
@@ -123,12 +123,12 @@ def predict(df_cmed, grouped_cmed, desc_ai, desc_pr, und):
                                                  desc_pr, und, ai_found)
     
     # Create process metadata for the whole matching process
-    process_metadata = match_ai_metadata
+    process_metadata = predict_ai_metadata
     process_metadata.update(filter_prs_metadata)
 
     return best_matches, process_metadata
 
-def match_ai(grouped_cmed, desc_ai):
+def predict_ai(grouped_cmed, desc_ai):
     """
     Predicts the most likely pharmaceutical active ingredient based on a given
     description.
@@ -151,24 +151,24 @@ def match_ai(grouped_cmed, desc_ai):
             - 'similarity_value': Similarity score of the best match.
     """
 
-    desc_ai = etl.sort_alphabetically(desc_ai)
-    best_match = -1
-    best_match_key = ""
+    # Sort the description alphabetically
+    desc_ai_sorted = etl.sort_alphabetically(desc_ai)
 
-    for i in range(len(grouped_cmed['key_sorted'])):
-        key_sorted = grouped_cmed['key_sorted'][i]
+    # Calculate the Jaro-Winkler similarity metric for each key in the grouped CMED data
+    metrics = grouped_cmed['key_sorted'] \
+              .map(lambda x: jaro_winkler_metric(desc_ai_sorted, x))
+    
+    # Find the index of the best match
+    best_idx = metrics.idxmax()
 
-        # Similarity calculation
-        metric = jaro_winkler_metric(desc_ai, key_sorted)
-
-        if metric >= best_match:
-            best_match = metric
-            best_match_key = grouped_cmed['key'][i]
+    # Get the best match key
+    best_match_key = grouped_cmed['key_sorted'][best_idx]
+    best_match_value = metrics[best_idx]
 
     process_metadata = {'desc_ai': desc_ai,
-                        'similarity_value': best_match}
+                        'similarity_value': best_match_value}
 
-    return (best_match_key, process_metadata)
+    return best_match_key, process_metadata
 
 def filter_prs(df_cmed_filtered, desc_ai, desc_pr, und, active_ingredient):
     """

--- a/ir_med.py
+++ b/ir_med.py
@@ -116,7 +116,7 @@ def predict(df_cmed, grouped_cmed, desc_ai, desc_pr, und):
 
     # Colect medicines that have the active ingredient
     idxs = grouped_cmed.loc[grouped_cmed['key'] == ai_found, 'indexes']
-    df_cmed_filtered = df_cmed.iloc[idxs]
+    df_cmed_filtered = df_cmed.iloc[idxs.values[0]]
 
     # Filter medicines based on the pharmaceutical presentation
     best_matches, filter_prs_metadata = filter_prs(df_cmed_filtered, desc_ai,


### PR DESCRIPTION
# Overview
This PR refactors several core functions in the CMED processing pipeline to improve code clarity, reduce redundancy, and align naming conventions. It also includes docstring updates and minor performance optimizations.

# Changes

## Function Renaming

- match_ai → predict_ai
- filter_prs → match_presentations
- get_sets_from_desc_pr → extract_ngrams
- sep_desc → split_description
- extract_relevant_words → identify_relevant_words
- grouped_cmed → group_cmed
- std_cold_names → std_cols_names_preprocessing

## Logic Improvements

- Replaced several for loops with list comprehensions, DataFrame.map(), or groupby().agg() to simplify logic and improve readability.
- Removed redundant parameters (e.g., desc_ai, active_ingredient) in match_presentations, which are no longer necessary after recent updates.
- Applied word_tokenize earlier in processing to reduce repeated calls and clarify intent.
- Replaced list.extend() with the + operator for better readability.
- Fixed a bug in predict related to incorrect use of the idxs variable.

## Preprocessing Cleanup

- Simplified std_preprocess by:
- - Using dict.get() instead of multiple conditional lookups.
- -  Replacing re.split() with re.findall() for more reliable pattern matching.
- - Using str.isdigit() over regex in number removal steps.
- Refactored std_col_names to use a single list comprehension for renaming columns.
- Removed unnecessary intermediate variables across functions for cleaner logic.

## Docstring and Documentation Updates

- Revised function and parameter descriptions for clarity.
- Removed outdated references in docstrings.
- Updated explanations for process_metadata and the similarity_value field.